### PR TITLE
Fix Hangfire initialization

### DIFF
--- a/webapi/src/MccSoft.TemplateApp.App/Jobs/ProductDataLoggerJob.cs
+++ b/webapi/src/MccSoft.TemplateApp.App/Jobs/ProductDataLoggerJob.cs
@@ -1,0 +1,34 @@
+using MccSoft.TemplateApp.Persistence;
+
+namespace MccSoft.TemplateApp.App.Jobs
+{
+    public class ProductDataLoggerJob : JobBase
+    {
+        private readonly ILogger<ProductDataLoggerJob> _logger;
+        private readonly TemplateAppDbContext _db;
+
+        public ProductDataLoggerJob(ILogger<ProductDataLoggerJob> logger, TemplateAppDbContext db)
+            : base(logger)
+        {
+            _logger = logger;
+            _db = db;
+        }
+
+        protected override async Task ExecuteCore()
+        {
+            var operationName = nameof(ProductDataLoggerJob);
+            _logger.LogInformation($"Starting {operationName} scheduler job");
+
+            List<int> studiesToSync = new List<int>();
+
+            var dbEntities = _db.Products.ToList();
+
+            foreach (var dbEntity in dbEntities)
+            {
+                _logger.LogInformation($"Product in DB: {dbEntity.Title} ");
+            }
+
+            _logger.LogInformation($"Finished {operationName}");
+        }
+    }
+}

--- a/webapi/src/MccSoft.TemplateApp.App/Settings/ProductDataLoggerJobSettings.cs
+++ b/webapi/src/MccSoft.TemplateApp.App/Settings/ProductDataLoggerJobSettings.cs
@@ -1,0 +1,3 @@
+﻿namespace MccSoft.TemplateApp.App.Settings;
+
+public class ProductDataLoggerJobSettings : HangFireJobSettings { }

--- a/webapi/src/MccSoft.TemplateApp.App/appsettings.json
+++ b/webapi/src/MccSoft.TemplateApp.App/appsettings.json
@@ -153,5 +153,8 @@
     "Password": "871H2ZzBWAS5",
     "From": "mcc.template.app@gmail.com",
     "FromName": "Template App"
+  },
+  "ProductDataLoggerJobSettings": {
+    "CronExpression": "0 */1 * * *"
   }
 }


### PR DESCRIPTION
PR to provide proposal about Hangfire mentioned in issue #9 

- Use `IRecurringJobManager` from service's scope
- Added example (ProductDataLoggerJob)
  - Logs every our number of products.
- Added custom helpers for registering a Job and its Settings
  - `RegisterHangfireJobs` has added in the end of `AddHangfire`. This method calls registration Jobs for accessing via DI.
  - `ConfigureJob<T, TOptions>` has been added in the "use" section to register "Recurring Jobs" in Hangfire Server. The helper was added to minimize code in the `UseHangfire` middleware for further Jobs registration.
 