### PR TITLE
Replace default password with one that fits default validation rules.

### DIFF
--- a/scripts/mssql/start_mssql.ps1
+++ b/scripts/mssql/start_mssql.ps1
@@ -1,3 +1,3 @@
 docker volume create --name mssql-volume
 docker container rm mssql_db
-docker run --restart=always -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=superstrongpassword" -p 1433:1433 --name mssql_db --hostname mssql_db -d mcr.microsoft.com/mssql/server:2022-latest 
+docker run --restart=always -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=yourStrong(!)Password" -p 1433:1433 --name mssql_db --hostname mssql_db -d mcr.microsoft.com/mssql/server:2022-latest 


### PR DESCRIPTION
Current password that is used in powershell script to start up mssql does not match the requirements of MSSQL server passwords, which leads to failure of container starting up.