### PR TITLE
Adjust loggly registration condition and BasicApiTests failing conditions.

### DIFF
--- a/webapi/Lib/Logging/MccSoft.Logging/LoggerConfigurationExtensions.cs
+++ b/webapi/Lib/Logging/MccSoft.Logging/LoggerConfigurationExtensions.cs
@@ -135,8 +135,8 @@ namespace MccSoft.Logging
                         )
             );
 
-            // If the stage is not local development stage - push logs to Elasticsearch.
-            if (!string.IsNullOrEmpty(remoteLoggerOption?.Server))
+            // If the stage is not local development stage - push logs to Elasticsearch and loggly token is present.
+            if (!string.IsNullOrEmpty(remoteLoggerOption?.Server) && !string.IsNullOrEmpty(remoteLoggerOption.Token))
             {
                 loggerConfiguration.WriteTo.Logger(
                     lc =>

--- a/webapi/tests/MccSoft.TemplateApp.ComponentTests/BasicApiTests.cs
+++ b/webapi/tests/MccSoft.TemplateApp.ComponentTests/BasicApiTests.cs
@@ -10,7 +10,6 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using MccSoft.WebApi.Patching.Models;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using NJsonSchema;
 using NJsonSchema.CodeGeneration.TypeScript;
@@ -19,6 +18,7 @@ using NSwag.CodeGeneration.CSharp;
 using NSwag.CodeGeneration.TypeScript;
 using Xunit;
 using Xunit.Abstractions;
+using System.Text;
 
 namespace MccSoft.TemplateApp.ComponentTests
 {
@@ -51,12 +51,22 @@ namespace MccSoft.TemplateApp.ComponentTests
                 );
 
             using var scope = TestServer.Services.CreateScope();
+            var errors = new StringBuilder();
             foreach (Type controllerType in controllerTypes)
             {
-                // It will throw exception if any controller's dependency is not registered.
+                // It will throw exception if any controller's dependency is not registered.`
                 // (it doesn't require controllers themselves to be registered, as opposed to scope.GetService<T>())
-                ActivatorUtilities.CreateInstance(scope.ServiceProvider, controllerType);
+                try
+                {
+                    ActivatorUtilities.CreateInstance(scope.ServiceProvider, controllerType);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    errors.AppendLine(ex.Message);
+                }
             }
+
+            Assert.True(string.IsNullOrEmpty(errors.ToString()), errors.ToString());
         }
 
         /// <summary>


### PR DESCRIPTION
- Avoid loggly registration if loggly token missing. 
- Extend logging of BasicApiTests.AllControllersAreResolvable test errors to check all controllers before failing the test.